### PR TITLE
Resolve configuration

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,10 +5,11 @@ import Reactotron, {networking} from 'reactotron-react-native'
 
 Reactotron
   .configure({host: '192.168.0.21'}) //this is also the ip address that expo is using
-  .use(networking({
-    ignoreUrls: /\/(logs|symbolicate)$/,
-  }))
-  .useReactNative()
+  .useReactNative({
+    networking: {
+      ignoreUrls: /\/(logs|symbolicate)$/,
+    }
+  })
   .connect()
 
   export default class App extends React.Component {


### PR DESCRIPTION
When you call `useReactNative` it registers the `networking` plugin again but this time without your `ignoreUrls` configuration. Just move that on into `useReactNative` and your problem goes away :-)